### PR TITLE
Feat multiple energy test annotation per test class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ buildNumber.properties
 /.gradle/
 /bin/
 
+# IDEA 
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -130,10 +130,8 @@ The first one execute java command with call graph tool to create à call graph 
 
 #### How to write tests 
 
-The rules to respect are:
-
-- You must write only one energy test per file test class
-- You have to add this annotation on each energy test like 
+You have to add the annotation `@EnergyTest` on each energy, instead of classical `@Test` annotation.
+Following an example:  
 
 	//...
 	

--- a/src/main/java/org/powerapi/jjoules/junit/ReportRegister.java
+++ b/src/main/java/org/powerapi/jjoules/junit/ReportRegister.java
@@ -1,56 +1,55 @@
 /**
- * 
+ *
  */
 package org.powerapi.jjoules.junit;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * @author spirals
  *
  */
-public class ReportRegister{
+public class ReportRegister {
 
-	private String filename;
+    public static final String JSON_EXTENSION = ".json";
 
-	public void setFilename(String newFilename) {
-		this.filename = newFilename;
-	}
+    private final File reportsDir;
 
-	
-	public void jsonRegistreReport(Map<String, Long> reports) {
+    public ReportRegister() {
+        this.reportsDir = new File("target", "jjoules-reports");
+        if (!reportsDir.exists()) {
+            if (!reportsDir.mkdir()) {
+                throw new RuntimeException("Could not create " + reportsDir.getAbsolutePath());
+            }
+        }
+    }
 
+    public void save(String className, Method testMethod, Map<String, Long> report) {
+        final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        final File file = new File(reportsDir, className + "-" + testMethod.getName() + JSON_EXTENSION);
+        if (!file.exists()) {
+            try {
+                if (!file.createNewFile()) {
+                    throw new RuntimeException("Could not create " + file.getAbsolutePath());
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        try (FileWriter writer = new FileWriter(file.getAbsoluteFile())) {
+            writer.write(gson.toJson(report));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-		File reportsDir = new File("target","jjoules-reports");
-
-		if(! reportsDir.exists()) {
-			reportsDir.mkdir();
-		}
-
-		Gson gson = new Gson();
-
-		File file = new File(reportsDir,filename+".json");
-
-		if(! file.exists()) {
-			try {
-				file.createNewFile();
-			} catch(IOException e) {
-				e.printStackTrace();
-			}
-		}
-		try {
-			FileWriter fw = new FileWriter(file.getAbsoluteFile());
-			gson.toJson(gson.toJsonTree(reports),fw);
-			fw.flush();
-			fw.close();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
 
 }

--- a/src/test/java/org/powerapi/jjoules/AbstractTest.java
+++ b/src/test/java/org/powerapi/jjoules/AbstractTest.java
@@ -1,0 +1,31 @@
+package org.powerapi.jjoules;
+
+import org.junit.After;
+import org.junit.jupiter.api.AfterAll;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Benjamin DANGLOT
+ * benjamin.danglot@davidson.fr
+ * 28/10/2020
+ */
+public abstract class AbstractTest {
+
+    private static final String FOLDER_PATH = "target/jjoules-reports/";
+
+    protected List<String> pathToAssert = new ArrayList<>();
+
+    @After
+    public void tearsDown() {
+        for (String path : this.pathToAssert) {
+            final File reportFile = new File(FOLDER_PATH, path);
+            assertTrue(reportFile.exists());
+        }
+    }
+
+}

--- a/src/test/java/org/powerapi/jjoules/AbstractTest.java
+++ b/src/test/java/org/powerapi/jjoules/AbstractTest.java
@@ -1,7 +1,6 @@
 package org.powerapi.jjoules;
 
 import org.junit.After;
-import org.junit.jupiter.api.AfterAll;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/src/test/java/org/powerapi/jjoules/Test.java
+++ b/src/test/java/org/powerapi/jjoules/Test.java
@@ -1,0 +1,24 @@
+package org.powerapi.jjoules;
+
+import org.powerapi.jjoules.junit.EnergyTest;
+
+/**
+ * @author Benjamin DANGLOT
+ * benjamin.danglot@davidson.fr
+ * 28/10/2020
+ */
+public class Test extends AbstractTest {
+
+    @EnergyTest
+    public void method() {
+        System.out.println("1");
+        this.pathToAssert.add("org.powerapi.jjoules.Test-method1.json");
+    }
+
+    @EnergyTest
+    public void method2() {
+        System.out.println("2");
+        this.pathToAssert.add("org.powerapi.jjoules.Test-method2.json");
+    }
+
+}

--- a/src/test/java/org/powerapi/jjoules/junit/Test.java
+++ b/src/test/java/org/powerapi/jjoules/junit/Test.java
@@ -1,0 +1,24 @@
+package org.powerapi.jjoules.junit;
+
+import org.powerapi.jjoules.AbstractTest;
+
+/**
+ * @author Benjamin DANGLOT
+ * benjamin.danglot@davidson.fr
+ * 28/10/2020
+ */
+public class Test extends AbstractTest {
+
+    @EnergyTest
+    public void method() {
+        System.out.println("1");
+        this.pathToAssert.add("org.powerapi.jjoules.junit.Test-method1.json");
+    }
+
+    @EnergyTest
+    public void method2() {
+        System.out.println("2");
+        this.pathToAssert.add("org.powerapi.jjoules.junit.Test-method2.json");
+    }
+
+}


### PR DESCRIPTION
Hello,

I propose the following changes in order to have multiple `@EnergyTest` per test class.
**JUnit-jjoules** will generate one JSON file per test methods, named with the following convention: 

`full.quallified.name.test.class-testMethodName.json`

I also enable prettyprint in **GSON** taht allows users (humans) to look directly the JSON.

WDYT?

Thank you very much.